### PR TITLE
added finding geohashes in polygon

### DIFF
--- a/GearRent.xcodeproj/project.pbxproj
+++ b/GearRent.xcodeproj/project.pbxproj
@@ -38,6 +38,11 @@
 		E3A97C222880A0410021FC02 /* ReservationTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C212880A0410021FC02 /* ReservationTableViewCell.m */; };
 		E3A97C252881ED7C0021FC02 /* BookingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C242881ED7C0021FC02 /* BookingsViewController.m */; };
 		E3A97C2B28821AB30021FC02 /* BookingTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C2A28821AB30021FC02 /* BookingTableViewCell.m */; };
+		E3A97C38288885660021FC02 /* APIManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C37288885660021FC02 /* APIManager.m */; };
+		E3A97C40288885D70021FC02 /* GNBoundingBox.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C3A288885D70021FC02 /* GNBoundingBox.m */; };
+		E3A97C41288885D70021FC02 /* GNWGS84Point.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C3E288885D70021FC02 /* GNWGS84Point.m */; };
+		E3A97C42288885D70021FC02 /* GNGeoHash.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C3F288885D70021FC02 /* GNGeoHash.m */; };
+		E3A97C452888A9510021FC02 /* Edge.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A97C442888A9510021FC02 /* Edge.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -118,6 +123,16 @@
 		E3A97C242881ED7C0021FC02 /* BookingsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BookingsViewController.m; sourceTree = "<group>"; };
 		E3A97C2928821AB30021FC02 /* BookingTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookingTableViewCell.h; sourceTree = "<group>"; };
 		E3A97C2A28821AB30021FC02 /* BookingTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BookingTableViewCell.m; sourceTree = "<group>"; };
+		E3A97C36288885660021FC02 /* APIManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIManager.h; sourceTree = "<group>"; };
+		E3A97C37288885660021FC02 /* APIManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APIManager.m; sourceTree = "<group>"; };
+		E3A97C3A288885D70021FC02 /* GNBoundingBox.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GNBoundingBox.m; sourceTree = "<group>"; };
+		E3A97C3B288885D70021FC02 /* GNWGS84Point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GNWGS84Point.h; sourceTree = "<group>"; };
+		E3A97C3C288885D70021FC02 /* GNGeoHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GNGeoHash.h; sourceTree = "<group>"; };
+		E3A97C3D288885D70021FC02 /* GNBoundingBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GNBoundingBox.h; sourceTree = "<group>"; };
+		E3A97C3E288885D70021FC02 /* GNWGS84Point.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GNWGS84Point.m; sourceTree = "<group>"; };
+		E3A97C3F288885D70021FC02 /* GNGeoHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GNGeoHash.m; sourceTree = "<group>"; };
+		E3A97C432888A9510021FC02 /* Edge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Edge.h; sourceTree = "<group>"; };
+		E3A97C442888A9510021FC02 /* Edge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Edge.m; sourceTree = "<group>"; };
 		EC76620D764D40435206D1C0 /* Pods-GearRent-GearRentUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GearRent-GearRentUITests.release.xcconfig"; path = "Target Support Files/Pods-GearRent-GearRentUITests/Pods-GearRent-GearRentUITests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -199,6 +214,8 @@
 		E3A97BB12874A6AB0021FC02 /* GearRent */ = {
 			isa = PBXGroup;
 			children = (
+				E3A97C39288885890021FC02 /* Geohash */,
+				E3A97C35288885510021FC02 /* Networking */,
 				E3A97C2C288879D40021FC02 /* Views */,
 				E3A97C052878CEAE0021FC02 /* Models */,
 				E3A97BE72874A6C30021FC02 /* Delegates */,
@@ -286,6 +303,8 @@
 				E3A97C0A2878D46E0021FC02 /* Reservation.m */,
 				E3A97C0F2878D5E10021FC02 /* TimeInterval.h */,
 				E3A97C102878D5E10021FC02 /* TimeInterval.m */,
+				E3A97C432888A9510021FC02 /* Edge.h */,
+				E3A97C442888A9510021FC02 /* Edge.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -303,6 +322,28 @@
 				E3A97C0328778BA80021FC02 /* ImageCarouselCollectionViewCell.m */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		E3A97C35288885510021FC02 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				E3A97C36288885660021FC02 /* APIManager.h */,
+				E3A97C37288885660021FC02 /* APIManager.m */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		E3A97C39288885890021FC02 /* Geohash */ = {
+			isa = PBXGroup;
+			children = (
+				E3A97C3D288885D70021FC02 /* GNBoundingBox.h */,
+				E3A97C3A288885D70021FC02 /* GNBoundingBox.m */,
+				E3A97C3C288885D70021FC02 /* GNGeoHash.h */,
+				E3A97C3F288885D70021FC02 /* GNGeoHash.m */,
+				E3A97C3B288885D70021FC02 /* GNWGS84Point.h */,
+				E3A97C3E288885D70021FC02 /* GNWGS84Point.m */,
+			);
+			path = Geohash;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -543,16 +584,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E3A97C452888A9510021FC02 /* Edge.m in Sources */,
 				E3A97C252881ED7C0021FC02 /* BookingsViewController.m in Sources */,
 				E3A97C0B2878D46E0021FC02 /* Reservation.m in Sources */,
 				E3A97C0428778BA80021FC02 /* ImageCarouselCollectionViewCell.m in Sources */,
 				E3A97BB42874A6AB0021FC02 /* AppDelegate.m in Sources */,
 				E3A97BF42874F37F0021FC02 /* GearForRentViewController.m in Sources */,
+				E3A97C42288885D70021FC02 /* GNGeoHash.m in Sources */,
+				E3A97C40288885D70021FC02 /* GNBoundingBox.m in Sources */,
 				E3A97BF8287622170021FC02 /* ProfileViewController.m in Sources */,
 				E3A97C222880A0410021FC02 /* ReservationTableViewCell.m in Sources */,
 				E3A97BEB2874C15E0021FC02 /* GettingStartedViewController.m in Sources */,
 				E3A97BC52874A6AC0021FC02 /* main.m in Sources */,
 				E3A97BB72874A6AB0021FC02 /* SceneDelegate.m in Sources */,
+				E3A97C38288885660021FC02 /* APIManager.m in Sources */,
 				E3A97BF12874F1070021FC02 /* SignInViewController.m in Sources */,
 				E3A97C2B28821AB30021FC02 /* BookingTableViewCell.m in Sources */,
 				E3A97C112878D5E10021FC02 /* TimeInterval.m in Sources */,
@@ -562,6 +607,7 @@
 				E3A97BEE2874CEB10021FC02 /* VerifyEmailViewController.m in Sources */,
 				E3A97C0E2878D5290021FC02 /* Item.m in Sources */,
 				E3A97C16287CE18E0021FC02 /* ListingTableViewCell.m in Sources */,
+				E3A97C41288885D70021FC02 /* GNWGS84Point.m in Sources */,
 				E3A97C1F288099E40021FC02 /* ListingReservationsViewController.m in Sources */,
 				E3A97BFE287766D40021FC02 /* MyListingsViewController.m in Sources */,
 			);

--- a/GearRent.xcworkspace/xcuserdata/enino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/GearRent.xcworkspace/xcuserdata/enino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "EA50ED2D-C92C-4388-9A4A-1F288203C7CE"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "B828FCCE-F470-48F1-BFA1-5734E02D0867"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "GearRent/ViewControllers/GearForRentViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "174"
+            endingLineNumber = "174"
+            landmarkName = "-didChangeListing:"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/GearRent.xcworkspace/xcuserdata/enino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/GearRent.xcworkspace/xcuserdata/enino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "EA50ED2D-C92C-4388-9A4A-1F288203C7CE"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "F9E226C0-564C-42EF-9E91-42AAF63B041B"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "GearRent/ViewControllers/DetailsViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "178"
-            endingLineNumber = "178"
-            landmarkName = "-isDateReserved:"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/GearRent/Base.lproj/Main.storyboard
+++ b/GearRent/Base.lproj/Main.storyboard
@@ -240,7 +240,7 @@
             </objects>
             <point key="canvasLocation" x="103" y="789"/>
         </scene>
-        <!--Home-->
+        <!--Gear For Rent View Controller-->
         <scene sceneID="tQb-Ns-RaU">
             <objects>
                 <viewController storyboardIdentifier="GearForRentViewController" id="lfo-Q5-Z1C" customClass="GearForRentViewController" sceneMemberID="viewController">
@@ -249,7 +249,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gear for rent" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="my2-Dr-Gg9">
-                                <rect key="frame" x="30" y="104" width="146" height="27"/>
+                                <rect key="frame" x="30" y="148" width="146" height="27"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="146" id="301-P5-ZWw"/>
                                 </constraints>
@@ -258,7 +258,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="duf-Qh-adg">
-                                <rect key="frame" x="0.0" y="139" width="414" height="674"/>
+                                <rect key="frame" x="0.0" y="183" width="414" height="630"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="ListingTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListingTableViewCell" rowHeight="198" id="IqP-dv-z0y" customClass="ListingTableViewCell">
@@ -317,20 +317,56 @@
                                 </prototypes>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a1G-Da-JK1">
-                                <rect key="frame" x="323" y="44" width="76" height="31"/>
+                                <rect key="frame" x="323" y="88" width="76" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Log Out"/>
                                 <connections>
                                     <action selector="didLogOut:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="2Zp-Te-Cp6"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dui-rG-vLK">
+                                <rect key="frame" x="13" y="44" width="102" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Listing View"/>
+                                <connections>
+                                    <action selector="didChangeListing:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="h4h-hx-gYf"/>
+                                </connections>
+                            </button>
+                            <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" showsUserLocation="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i0z-mB-Msk">
+                                <rect key="frame" x="0.0" y="127" width="414" height="686"/>
+                            </mapView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EyR-LR-Eqx">
+                                <rect key="frame" x="264" y="752" width="120" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Remove Points"/>
+                                <connections>
+                                    <action selector="didRemovePoints:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="weE-qL-glm"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q2s-2x-eAY">
+                                <rect key="frame" x="30" y="752" width="124.5" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Search Polygon"/>
+                                <connections>
+                                    <action selector="didSearchPolygon:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="neM-g5-kTS"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ECP-49-BTE"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="Q2s-2x-eAY" firstAttribute="top" secondItem="i0z-mB-Msk" secondAttribute="bottom" constant="-61" id="0IW-oA-u6s"/>
+                            <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" id="7Gc-9G-NZu"/>
+                            <constraint firstItem="EyR-LR-Eqx" firstAttribute="trailing" secondItem="i0z-mB-Msk" secondAttribute="trailing" constant="-30" id="9em-hp-4I4"/>
                             <constraint firstItem="a1G-Da-JK1" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" id="AJA-6M-Bzs"/>
+                            <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="Q2s-2x-eAY" secondAttribute="leading" constant="-30" id="DwV-Il-3GY"/>
+                            <constraint firstItem="i0z-mB-Msk" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="39" id="F1c-9X-J3m"/>
                             <constraint firstItem="my2-Dr-Gg9" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="60" id="K6d-PW-813"/>
+                            <constraint firstItem="i0z-mB-Msk" firstAttribute="trailing" secondItem="ECP-49-BTE" secondAttribute="trailing" id="QbW-QO-17k"/>
+                            <constraint firstItem="i0z-mB-Msk" firstAttribute="bottom" secondItem="ECP-49-BTE" secondAttribute="bottom" id="Tql-Mg-9bJ"/>
                             <constraint firstItem="ECP-49-BTE" firstAttribute="bottom" secondItem="duf-Qh-adg" secondAttribute="bottom" id="WIy-2a-dPt"/>
+                            <constraint firstItem="EyR-LR-Eqx" firstAttribute="bottom" secondItem="i0z-mB-Msk" secondAttribute="bottom" constant="-30" id="az0-hL-kG3"/>
                             <constraint firstItem="duf-Qh-adg" firstAttribute="top" secondItem="my2-Dr-Gg9" secondAttribute="bottom" constant="8" id="bl8-Zv-rEF"/>
                             <constraint firstItem="duf-Qh-adg" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" id="d8I-kW-0rV"/>
                             <constraint firstItem="ECP-49-BTE" firstAttribute="trailing" secondItem="duf-Qh-adg" secondAttribute="trailing" id="htF-Sd-WnZ"/>
@@ -338,15 +374,18 @@
                             <constraint firstItem="my2-Dr-Gg9" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" constant="30" id="xfp-AG-lKc"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Home" id="tQ9-AA-FDZ"/>
                     <navigationItem key="navigationItem" id="sVQ-4h-WeU"/>
                     <connections>
+                        <outlet property="listingTypeButton" destination="Dui-rG-vLK" id="KaA-hv-bSN"/>
                         <outlet property="listingsTableView" destination="duf-Qh-adg" id="wQj-SV-Aih"/>
+                        <outlet property="mapView" destination="i0z-mB-Msk" id="fzd-iw-Crn"/>
+                        <outlet property="removePointsButton" destination="EyR-LR-Eqx" id="SWc-A0-m25"/>
+                        <outlet property="searchPolygonButton" destination="Q2s-2x-eAY" id="I7A-yX-o2Y"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bBk-WV-n2b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="192.75362318840581" y="1522.7678571428571"/>
+            <point key="canvasLocation" x="1102.8985507246377" y="1522.7678571428571"/>
         </scene>
         <!--My Listings-->
         <scene sceneID="4Qb-b1-0qA">
@@ -501,7 +540,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kbz-Lc-aVg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1250.7246376811595" y="1522.7678571428571"/>
+            <point key="canvasLocation" x="2160.8695652173915" y="1522.7678571428571"/>
         </scene>
         <!--Profile-->
         <scene sceneID="mI8-wX-Snh">
@@ -733,7 +772,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="2146" y="1523"/>
+            <point key="canvasLocation" x="3055.072463768116" y="1522.7678571428571"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="eXS-Ri-nig">
@@ -1395,7 +1434,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zk7-Dp-Op6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3088" y="1523"/>
+            <point key="canvasLocation" x="3997.1014492753625" y="1522.7678571428571"/>
         </scene>
         <!--Profile Image Picker View Controller-->
         <scene sceneID="4YY-AQ-JUF">
@@ -1480,7 +1519,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="e8W-O3-wcz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4149" y="1523"/>
+            <point key="canvasLocation" x="5057.971014492754" y="1522.7678571428571"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="ZmT-IS-9Nl">
@@ -1492,7 +1531,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="lfo-Q5-Z1C" kind="relationship" relationship="viewControllers" id="o7F-Ql-tug"/>
+                        <segue destination="Wf9-WG-bDB" kind="relationship" relationship="viewControllers" id="o7F-Ql-tug"/>
                         <segue destination="U4Z-gW-dIO" kind="relationship" relationship="viewControllers" id="cnR-d3-Us9"/>
                         <segue destination="21H-Q5-6ef" kind="relationship" relationship="viewControllers" id="4OV-VG-gLW"/>
                         <segue destination="9I9-8h-mJx" kind="relationship" relationship="viewControllers" id="0wT-Tw-f2H"/>
@@ -1650,6 +1689,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UAI-XV-dWa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1879.7101449275365" y="123.88392857142857"/>
+        </scene>
+        <!--Home-->
+        <scene sceneID="Xxs-M7-ouw">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wf9-WG-bDB" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Home" id="tQ9-AA-FDZ"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="kNE-sV-dcP">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="lfo-Q5-Z1C" kind="relationship" relationship="rootViewController" id="AHM-dR-k8y"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="KWD-Yg-dX6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="192.75362318840581" y="1522.7678571428571"/>
         </scene>
     </scenes>
     <resources>

--- a/GearRent/Base.lproj/Main.storyboard
+++ b/GearRent/Base.lproj/Main.storyboard
@@ -316,23 +316,6 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a1G-Da-JK1">
-                                <rect key="frame" x="323" y="88" width="76" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Log Out"/>
-                                <connections>
-                                    <action selector="didLogOut:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="2Zp-Te-Cp6"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dui-rG-vLK">
-                                <rect key="frame" x="13" y="44" width="102" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Listing View"/>
-                                <connections>
-                                    <action selector="didChangeListing:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="h4h-hx-gYf"/>
-                                </connections>
-                            </button>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" showsUserLocation="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i0z-mB-Msk">
                                 <rect key="frame" x="0.0" y="127" width="414" height="686"/>
                             </mapView>
@@ -359,7 +342,6 @@
                             <constraint firstItem="Q2s-2x-eAY" firstAttribute="top" secondItem="i0z-mB-Msk" secondAttribute="bottom" constant="-61" id="0IW-oA-u6s"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" id="7Gc-9G-NZu"/>
                             <constraint firstItem="EyR-LR-Eqx" firstAttribute="trailing" secondItem="i0z-mB-Msk" secondAttribute="trailing" constant="-30" id="9em-hp-4I4"/>
-                            <constraint firstItem="a1G-Da-JK1" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" id="AJA-6M-Bzs"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="Q2s-2x-eAY" secondAttribute="leading" constant="-30" id="DwV-Il-3GY"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="39" id="F1c-9X-J3m"/>
                             <constraint firstItem="my2-Dr-Gg9" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="60" id="K6d-PW-813"/>
@@ -370,11 +352,33 @@
                             <constraint firstItem="duf-Qh-adg" firstAttribute="top" secondItem="my2-Dr-Gg9" secondAttribute="bottom" constant="8" id="bl8-Zv-rEF"/>
                             <constraint firstItem="duf-Qh-adg" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" id="d8I-kW-0rV"/>
                             <constraint firstItem="ECP-49-BTE" firstAttribute="trailing" secondItem="duf-Qh-adg" secondAttribute="trailing" id="htF-Sd-WnZ"/>
-                            <constraint firstItem="ECP-49-BTE" firstAttribute="trailing" secondItem="a1G-Da-JK1" secondAttribute="trailing" constant="15" id="s2P-U1-2Jr"/>
                             <constraint firstItem="my2-Dr-Gg9" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" constant="30" id="xfp-AG-lKc"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="sVQ-4h-WeU"/>
+                    <navigationItem key="navigationItem" id="sVQ-4h-WeU">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="f3W-kO-mkQ">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="Dui-rG-vLK">
+                                <rect key="frame" x="20" y="5" width="115.5" height="34.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Listing View"/>
+                                <connections>
+                                    <action selector="didChangeListing:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="h4h-hx-gYf"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="gt2-E6-qSm">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="a1G-Da-JK1">
+                                <rect key="frame" x="309" y="5" width="85" height="34.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Log Out"/>
+                                <connections>
+                                    <action selector="didLogOut:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="2Zp-Te-Cp6"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="listingTypeButton" destination="Dui-rG-vLK" id="KaA-hv-bSN"/>
                         <outlet property="listingsTableView" destination="duf-Qh-adg" id="wQj-SV-Aih"/>

--- a/GearRent/Geohash/GNBoundingBox.h
+++ b/GearRent/Geohash/GNBoundingBox.h
@@ -1,0 +1,43 @@
+//
+//  GNBoundingBox.h
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+/**
+ * GNBoundingBox encapsulates areas on the earths surface represented by two point that are maximum Latitude/Longitude and minimum Latitude/Longitude.<br>
+ * Coordinate projections might end up using this class...
+ */
+
+#import <Foundation/Foundation.h>
+#import "GNWGS84Point.h"
+
+@interface GNBoundingBox : NSObject
+
+@property(assign)long serialVersionUID;
+@property(assign)double maxLat;
+@property(assign)double maxLon;
+@property(assign)double minLat;
+@property(assign)double minLon;
+
+- (id) initWithY1:(double)y1 andY2:(double)y2 andX1:(double)x1 andX2:(double)x2;
+- (id) initWithP1:(GNWGS84Point*) p1 andP2:(GNWGS84Point*) p2;
+
+- (GNWGS84Point*) getUpperLeft;
+- (GNWGS84Point*) getLowerRight;
+@end

--- a/GearRent/Geohash/GNBoundingBox.m
+++ b/GearRent/Geohash/GNBoundingBox.m
@@ -1,0 +1,68 @@
+//
+//  GNBoundingBox.m
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import "GNBoundingBox.h"
+
+
+@implementation GNBoundingBox
+
+@synthesize serialVersionUID,maxLat,maxLon,minLat,minLon;
+
+/**
+ * create a bounding box defined by two coordinates
+ */
+- (id) initWithP1:(GNWGS84Point*) p1 andP2:(GNWGS84Point*) p2 
+{
+    //Initialization of an area based on two points
+    return [self initWithY1:p1.latitude andY2:p2.latitude andX1:p1.longitude andX2:p2.longitude];
+}
+
+- (id) initWithY1:(double)y1 andY2:(double)y2 andX1:(double)x1 andX2:(double)x2
+{
+    //Initialization of an area based on x/y coordinates
+    if (self = [super init])
+    {
+        self.minLon = fmin(x1, x2);
+        self.maxLon = fmax(x1, x2);
+        self.minLat = fmin(y1, y2);
+        self.maxLat = fmax(y1, y2);
+    }
+    return self;
+}
+
+- (NSString*) description 
+{
+    //Definition of string output for object
+    return [NSString stringWithFormat:@"%@ -> %@",[self getUpperLeft],[self getLowerRight]];
+}
+
+- (GNWGS84Point*) getUpperLeft
+{
+    //Returns the upper left point of the area
+    return [[GNWGS84Point alloc] initWithLatitude:self.maxLat andLongitude:self.minLon];
+}
+
+- (GNWGS84Point*) getLowerRight
+{
+    //Returns the lower right point of the area
+    return [[GNWGS84Point alloc] initWithLatitude:self.minLat andLongitude:self.maxLon];
+}
+@end

--- a/GearRent/Geohash/GNGeoHash.h
+++ b/GearRent/Geohash/GNGeoHash.h
@@ -1,0 +1,69 @@
+//
+//  GNGeoHash.h
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import <Foundation/Foundation.h>
+#import "GNWGS84Point.h"
+#import "GNBoundingBox.h"
+
+#define BASE32_BITS 5
+
+@interface GNGeoHash : NSObject
+
+@property(strong)NSMutableArray *BITS; 
+@property(assign)long long FIRST_BIT_FLAGGED;
+@property(strong)NSString *base32;
+@property(strong)NSDictionary *decodeMap;
+@property(assign)long long bits;
+@property(assign)Byte significantBits;
+@property(strong)GNWGS84Point *point;
+@property(strong)GNBoundingBox *boundingBox;
+
+-(id) initWithLatitude:(double)lat andLongitude:(double)lon andPrecision:(int)precision;
+- (NSString*) toBase32;
++ (long long) unsignedRightShiftWith:(long long) number andDigits:(int) digits;
+
+- (NSString*) toBinaryString;
++ (NSString*) toBinaryString:(long long)theNumber;
++ (GNGeoHash*) withCharacterPrecision:(double)latitude andLongitude:(double)longitude andNumberOfCharacters:(int) numberOfCharacters;
+
+- (void) divideRangeEncode:(double)value andRange:(NSMutableArray*) range;
+- (void) addOnBitToEnd;
+- (void) addOffBitToEnd;
+
+
+- (NSArray*) getAdjacent;
+- (GNGeoHash*) getNorthernNeighbour;
+- (GNGeoHash*) getSouthernNeighbour;
+- (GNGeoHash*) getEasternNeighbour;
+- (GNGeoHash*) getWesternNeighbour;
+
+- (NSMutableArray*) getRightAlignedLatitudeBits;
+- (NSMutableArray*) getRightAlignedLongitudeBits;
+- (long long) extractEverySecondBit:(long long) copyOfBits andNumberOfBits:(int)numberOfBits;
+- (NSArray*) getNumberOfLatLonBits;
+
+- (GNGeoHash*) recombineLatLonBitsToHash:(NSMutableArray*)latBits andLongBits:(NSMutableArray*)lonBits;
++ (void) divideRangeDecode:(GNGeoHash*) hash andRange:(NSMutableArray*)range andBool:(BOOL) b ;
+
++ (void) setBoundingBox:(GNGeoHash*)hash andLatitudeRange:(NSMutableArray*) latitudeRange andLongitudeRange:(NSMutableArray*) longitudeRange;
+
+- (NSUInteger)hash;
+@end

--- a/GearRent/Geohash/GNGeoHash.h
+++ b/GearRent/Geohash/GNGeoHash.h
@@ -66,4 +66,5 @@
 + (void) setBoundingBox:(GNGeoHash*)hash andLatitudeRange:(NSMutableArray*) latitudeRange andLongitudeRange:(NSMutableArray*) longitudeRange;
 
 - (NSUInteger)hash;
+
 @end

--- a/GearRent/Geohash/GNGeoHash.m
+++ b/GearRent/Geohash/GNGeoHash.m
@@ -1,0 +1,441 @@
+//
+//  GNGeoHash.m
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//  
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import "GNGeoHash.h"
+
+@interface GNGeoHash ()
+
+@end
+
+@implementation GNGeoHash 
+
+@synthesize BITS,FIRST_BIT_FLAGGED,base32,decodeMap,bits,significantBits,point,boundingBox;
+
+-(id)init
+{
+    //Initialize GeoHash standard values
+    if (self = [super init])
+    {
+        self.BITS = [NSMutableArray arrayWithObjects:[NSNumber numberWithInt:0],[NSNumber numberWithInt:0],[NSNumber numberWithInt:0],[NSNumber numberWithInt:0],[NSNumber numberWithInt:0],nil];
+        int val = 16;
+        for (int i = 0 ; i < 5 ; i++)
+        {
+            [self.BITS replaceObjectAtIndex:i withObject:[NSNumber numberWithInt:val]];
+            val /= 2; 
+            
+        }
+       
+        self.FIRST_BIT_FLAGGED = 0x8000000000000000l;
+        
+        self.base32 = @"0123456789bcdefghjkmnpqrstuvwxyz";
+        
+        NSMutableDictionary *tmp = [[NSMutableDictionary alloc] initWithCapacity:32];
+        int sz = [base32 length];
+        
+        for (int i = 0; i < sz; i++)
+        {
+            [tmp setValue:[NSNumber numberWithInt:i] forKey:[NSString stringWithFormat:@"%c",[self.base32 characterAtIndex:i]]];
+        }
+             
+        self.decodeMap = [NSDictionary dictionaryWithDictionary:tmp];
+        
+        self.bits = 0;
+        self.significantBits = 0;
+    }
+    return self;
+}
+
+
+-(id) initWithLatitude:(double)lat andLongitude:(double)lon andPrecision:(int)precision
+{
+    //Initialize GeoHash with certain GNWGS84Point
+    if ([self init])
+    {
+        self.point = [[GNWGS84Point alloc] initWithLatitude:lat andLongitude:lon];
+        
+        precision = fmin(precision, 64);
+        
+        BOOL isEvenBit = true;
+        
+        NSMutableArray *latitudeRange = [NSMutableArray arrayWithObjects: [NSNumber numberWithDouble:-90] ,[NSNumber numberWithDouble:90], nil];
+        NSMutableArray *longitudeRange = [NSMutableArray arrayWithObjects: [NSNumber numberWithDouble:-180] ,[NSNumber numberWithDouble:180], nil];
+        
+        while (self.significantBits < precision)
+        {
+            if (isEvenBit) 
+            {
+                [self divideRangeEncode:lon andRange:longitudeRange];
+            } 
+            else 
+            {
+                [self divideRangeEncode:lat andRange:latitudeRange];
+            }
+            
+            isEvenBit = !isEvenBit;
+        }
+        
+        [GNGeoHash setBoundingBox:self andLatitudeRange:latitudeRange andLongitudeRange:longitudeRange];
+        self.bits <<= (64 - precision);
+    }
+    return self;
+}
+
+- (NSString*) description
+{
+    if (significantBits % 5 == 0)
+    {
+        return [NSString stringWithFormat:@"%@ -> %@ -> %@", [GNGeoHash toBinaryString:self.bits], self.boundingBox, [self toBase32]];
+    }
+    else
+    {
+        return [NSString stringWithFormat:@"%@ -> %@, bits: %c", [GNGeoHash toBinaryString:self.bits], self.boundingBox, self.significantBits];
+    }    
+}
+
++ (GNGeoHash*) withCharacterPrecision:(double)latitude andLongitude:(double)longitude andNumberOfCharacters:(int) numberOfCharacters 
+{
+    int desiredPrecision = (numberOfCharacters * 5 <= 60) ? numberOfCharacters * 5: 60;
+    
+    return [[GNGeoHash alloc] initWithLatitude:latitude andLongitude:longitude andPrecision:desiredPrecision];
+}
+
++ (NSString*) toBinaryString:(long long)theNumber
+{
+    //Returns a number as binary string representation
+    NSMutableString* binaryString = [[NSMutableString alloc] initWithCapacity:1];
+    long long numberCopy = theNumber;
+    
+    for(int i = 0; i < 64; i++)
+    {
+        // Prepend "0" or "1", depending on the bit
+        // (Binary is read right to left)
+        [binaryString insertString:((numberCopy & 1) ? @"1" : @"0") atIndex:0];
+        numberCopy = [GNGeoHash unsignedRightShiftWith:numberCopy andDigits:1];
+
+    }
+    return binaryString;
+}
+
+- (NSString*) toBinaryString
+{
+    //Transform hash bits to binary strings
+    NSString* buf = @"";
+    long long bitsCopy = bits;
+    
+    for (int i = 0; i < significantBits; i++)
+    {
+        if ((bitsCopy & FIRST_BIT_FLAGGED) == FIRST_BIT_FLAGGED)
+        {
+            [buf stringByAppendingString:@"1"];
+        }
+        else
+        {
+            [buf stringByAppendingString:@"0"];
+        }
+        
+        bitsCopy <<= 1;
+    }
+    
+    return buf;
+}
+
+
+- (void) divideRangeEncode:(double)value andRange:(NSMutableArray*) range
+{
+    //Transform latitude/longitude value to bit representation
+    double mid = 0;
+    if ([range count] > 1)
+    {
+        double dNumber1 = [[range objectAtIndex:0] doubleValue];
+        double dNumber2 = [[range objectAtIndex:1] doubleValue];
+        mid = (dNumber1 + dNumber2) / 2;
+    }
+    
+    if (value >= mid) 
+    {
+        [self addOnBitToEnd];
+        [range replaceObjectAtIndex:0 withObject:[NSNumber numberWithDouble:mid]];
+    } 
+    else 
+    {
+        [self addOffBitToEnd];
+        [range replaceObjectAtIndex:1 withObject:[NSNumber numberWithDouble:mid]];
+    }
+}
+
+- (void) addOnBitToEnd
+{
+    self.significantBits++;
+    //Bitwise left shift, adding a zero
+    self.bits <<= 1;
+    //Set introduced bit to 1 (0x1 representes 1 in Hex and is OR connected to the value)
+    self.bits = bits | 0x1;
+}
+
+- (void) addOffBitToEnd
+{
+    self.significantBits++;
+    //Bitwise left shift, adding a zero
+    self.bits <<= 1;
+}
+
++ (void) setBoundingBox:(GNGeoHash*)hash andLatitudeRange:(NSMutableArray*) latitudeRange andLongitudeRange:(NSMutableArray*) longitudeRange 
+{
+    //Set location area based on two points
+    GNWGS84Point* p1 = [[GNWGS84Point alloc] initWithLatitude:[[latitudeRange objectAtIndex:0]doubleValue] andLongitude:[[longitudeRange objectAtIndex:0]doubleValue]];
+    GNWGS84Point* p2 = [[GNWGS84Point alloc] initWithLatitude:[[latitudeRange objectAtIndex:1]doubleValue] andLongitude:[[longitudeRange objectAtIndex:1]doubleValue]];
+    hash.boundingBox = [[GNBoundingBox alloc] initWithP1:p1 andP2:p2];
+}
+
+/**
+ * returns the 8 adjacent hashes for this one. They are in the following
+ * order:<br>
+ * N, NE, E, SE, S, SW, W, NW
+ */
+- (NSArray*) getAdjacent 
+{
+    //Find neighbors of a given area
+    GNGeoHash *northern = [self getNorthernNeighbour];
+    GNGeoHash *eastern = [self getEasternNeighbour];
+    GNGeoHash *southern = [self getSouthernNeighbour];
+    GNGeoHash *western = [self getWesternNeighbour];
+    
+    return [NSArray arrayWithObjects:northern, [northern getEasternNeighbour], eastern, [southern getEasternNeighbour], southern,
+            [southern getWesternNeighbour], western, [northern getWesternNeighbour], nil];
+    return [[NSArray alloc] init];
+}
+
+- (GNGeoHash*) getNorthernNeighbour 
+{
+    //Find northern area corresponding to the given area through changing latitude
+    NSMutableArray *latitudeBits = [self getRightAlignedLatitudeBits];
+    NSMutableArray *longitudeBits = [self getRightAlignedLongitudeBits];
+    long long value = [[latitudeBits objectAtIndex:0] longLongValue] + 1;    
+    [latitudeBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:value]];
+
+    return [self recombineLatLonBitsToHash:latitudeBits andLongBits:longitudeBits];    
+}
+
+- (GNGeoHash*) getSouthernNeighbour 
+{
+    //Find southern area corresponding to the given area through changing latitude
+    NSMutableArray *latitudeBits = [self getRightAlignedLatitudeBits];
+    NSMutableArray *longitudeBits = [self getRightAlignedLongitudeBits];
+    long long value = [[latitudeBits objectAtIndex:0] longLongValue] - 1;
+    [latitudeBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:value]];
+    
+    return [self recombineLatLonBitsToHash:latitudeBits andLongBits:longitudeBits];    
+}
+
+- (GNGeoHash*) getEasternNeighbour 
+{
+    //Find eastern area corresponding to the given area through changing longitude
+    
+    NSMutableArray *latitudeBits = [self getRightAlignedLatitudeBits];
+    NSMutableArray *longitudeBits = [self getRightAlignedLongitudeBits];
+    long long value = [[longitudeBits objectAtIndex:0]longLongValue] + 1;
+    [longitudeBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:value]];
+    
+    return [self recombineLatLonBitsToHash:latitudeBits andLongBits:longitudeBits];    
+}
+
+- (GNGeoHash*) getWesternNeighbour 
+{
+    //Find western area corresponding to the given area through changing longitude
+    NSMutableArray *latitudeBits = [self getRightAlignedLatitudeBits];
+    NSMutableArray *longitudeBits = [self getRightAlignedLongitudeBits];
+    long long value = [[longitudeBits objectAtIndex:0]longLongValue] - 1;
+    [longitudeBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:value]];
+    
+    return [self recombineLatLonBitsToHash:latitudeBits andLongBits:longitudeBits];    
+}
+
+- (NSMutableArray*) getRightAlignedLatitudeBits
+{
+    //Identifies each second bit relevant for latitude starting from the second bit
+    
+    long long copyOfBits = self.bits << 1;
+    long numberOfLatBits = [[[self getNumberOfLatLonBits] objectAtIndex:0] longValue];
+    long long value = [self extractEverySecondBit:copyOfBits andNumberOfBits:numberOfLatBits];
+    
+    return [NSMutableArray arrayWithObjects:[NSNumber numberWithLongLong:value],[NSNumber numberWithLong:(int)numberOfLatBits], nil];
+}
+
+- (NSMutableArray*) getRightAlignedLongitudeBits
+{
+    //Identifies each second bit relevant for longitude starting from the first bit
+    long long copyOfBits = self.bits;
+    long numberOfLonBits = [[[self getNumberOfLatLonBits] objectAtIndex:1] longValue];
+    long long value = [self extractEverySecondBit:copyOfBits andNumberOfBits:numberOfLonBits];
+    
+    return [NSMutableArray arrayWithObjects:[NSNumber numberWithLongLong:value],[NSNumber numberWithLong:(int)numberOfLonBits], nil];
+}
+
+- (NSArray*) getNumberOfLatLonBits
+{
+    //Calculates the amount of latitude and longitude related bits
+    long halfvalue = self.significantBits / 2;
+    long halfvaluePlusOne = self.significantBits / 2 + 1;
+    
+    if (self.significantBits % 2 == 0)
+    {
+        NSArray* array = [NSArray arrayWithObjects:[NSNumber numberWithInt:halfvalue], [NSNumber numberWithLong:halfvalue], nil];
+        return array;
+    }
+    else
+    {
+        NSArray* array = [NSArray arrayWithObjects:[NSNumber numberWithInt:halfvalue], [NSNumber numberWithLong:halfvaluePlusOne], nil];
+        return array;
+    }
+}
+
+- (long long) extractEverySecondBit:(long long) copyOfBits andNumberOfBits:(int)numberOfBits
+{
+    //Returns each second bit of a value (extract either longitude or latitude related bits)
+    long long value = 0;
+    
+    for (int i = 0; i < numberOfBits; i++)
+    {
+        if ((copyOfBits & self.FIRST_BIT_FLAGGED) == self.FIRST_BIT_FLAGGED)
+        {
+            value |= 0x1;
+        }
+        
+        value <<= 1;
+        copyOfBits <<= 2;
+    }
+    //Undo last left shift
+    value = [GNGeoHash unsignedRightShiftWith:value andDigits:1];
+    
+    return value;
+}
+
+- (GNGeoHash*) recombineLatLonBitsToHash:(NSMutableArray*)latBits andLongBits:(NSMutableArray*)lonBits; 
+{
+    //Build the new bit representation of latitude/longitude based on the seperate lat and lon bit chains
+    GNGeoHash *hash = [[GNGeoHash alloc] init];
+    BOOL isEvenBit = false;
+    
+    long long latValue = [[latBits objectAtIndex:0]longLongValue];
+    long long lonValue = [[lonBits objectAtIndex:0]longLongValue];
+    
+    latValue <<= (64 - [[latBits objectAtIndex:1]longValue]);
+    lonValue <<= (64 - [[lonBits objectAtIndex:1]longValue]);
+    
+    [latBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:latValue]];
+    [lonBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:lonValue]];
+    
+    NSMutableArray *latitudeRange = [NSMutableArray arrayWithObjects: [NSNumber numberWithDouble:-90] ,[NSNumber numberWithDouble:90], nil];
+    NSMutableArray *longitudeRange = [NSMutableArray arrayWithObjects: [NSNumber numberWithDouble:-180] ,[NSNumber numberWithDouble:180], nil];
+
+    for (int i = 0; i < ([[latBits objectAtIndex:1]longValue] + [[lonBits objectAtIndex:1]longValue]); i++) 
+    {
+        if (isEvenBit) 
+        {
+            [GNGeoHash divideRangeDecode:hash andRange:latitudeRange andBool:([[latBits objectAtIndex:0]longLongValue] & self.FIRST_BIT_FLAGGED) == self.FIRST_BIT_FLAGGED];
+
+            latValue <<= 1;
+            [latBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:latValue]];
+        } else {
+            [GNGeoHash divideRangeDecode:hash andRange:longitudeRange andBool:([[lonBits objectAtIndex:0]longLongValue] & self.FIRST_BIT_FLAGGED) == self.FIRST_BIT_FLAGGED];
+            lonValue <<= 1;
+            [lonBits replaceObjectAtIndex:0 withObject:[NSNumber numberWithLongLong:lonValue]];
+        }
+        
+        isEvenBit = !isEvenBit;
+    }
+
+    hash.bits <<= (64 - hash.significantBits);
+    [GNGeoHash setBoundingBox:hash andLatitudeRange:latitudeRange andLongitudeRange:longitudeRange];
+    
+    double pointLatitude = [[latitudeRange objectAtIndex:0]doubleValue] + ([[latitudeRange objectAtIndex:1]doubleValue] - [[latitudeRange objectAtIndex:0]doubleValue]) / 2;
+
+    double pointLongitude = [[longitudeRange objectAtIndex:0]doubleValue] + ([[longitudeRange objectAtIndex:1]doubleValue] - [[longitudeRange objectAtIndex:0]doubleValue]) / 2;
+    
+    hash.point = [[GNWGS84Point alloc] initWithLatitude:pointLatitude andLongitude:pointLongitude];
+    
+    return hash;
+}
+
++ (void) divideRangeDecode:(GNGeoHash*) hash andRange:(NSMutableArray*)range andBool:(BOOL) b 
+{
+    //Calculate Latitude/Longitude values based on bit representation and set bits
+    double mid = ([[range objectAtIndex:0] doubleValue] + [[range objectAtIndex:1] doubleValue]) / 2;
+    
+    if (b)
+    {
+        [hash addOnBitToEnd];
+        [range replaceObjectAtIndex:0 withObject:[NSNumber numberWithDouble:mid]];
+    }
+    else
+    {
+        [hash addOffBitToEnd];
+        [range replaceObjectAtIndex:1 withObject:[NSNumber numberWithDouble:mid]];
+    }
+}
+
+
+- (NSString*) toBase32
+{
+    //Transfer bit representation to Base32 representation of the location
+    if (self.significantBits % 5 != 0)
+    {
+        return @"";
+    }
+
+    NSString* buf = @"";
+    long long firstFiveBitsMask = 0xf800000000000000l;
+    long long bitsCopy = self.bits;
+    int partialChunks = (int) ceil(((double) self.significantBits / 5));
+    
+    for (int i = 0; i < partialChunks; i++)
+    {
+        int pointer = (int) [GNGeoHash unsignedRightShiftWith:(bitsCopy & firstFiveBitsMask) andDigits: 59];
+        buf = [buf stringByAppendingString:[NSString stringWithFormat:@"%c", [self.base32 characterAtIndex:pointer]]];
+        bitsCopy <<= 5;
+    }
+    
+    return buf;
+}
+
++ (long long) unsignedRightShiftWith:(long long) number andDigits:(int) digits
+{
+    //After each right shift, set new digit (leftmost) to zero as it will be 1 if the former first bit (left most) was 1
+    //That is because this bit represents a negative signed int and in objective c this flag will remain
+    for (int i = 0; i < digits; i++)
+    {
+        number >>= 1;
+        number &= 0x7fffffffffffffffl;
+    }
+    return number;
+}
+
+- (BOOL)isEqual:(id)other
+{
+        return [[self toBase32] isEqual:[other toBase32]];
+}
+
+- (NSUInteger)hash
+{
+    return [[self toBase32] hash];
+}
+
+@end

--- a/GearRent/Geohash/GNWGS84Point.h
+++ b/GearRent/Geohash/GNWGS84Point.h
@@ -1,0 +1,37 @@
+//
+//  GNWGS84Point.h
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+/**
+ * GNWGS84Point encapsulates coordinates on the earths surface.<br>
+ * Coordinate projections might end up using this class...
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface GNWGS84Point : NSObject
+
+@property(assign) double latitude;
+@property(assign) double longitude;
+
+-(id) initWithLatitude:(double)lat andLongitude:(double)lon;
+
+@end

--- a/GearRent/Geohash/GNWGS84Point.m
+++ b/GearRent/Geohash/GNWGS84Point.m
@@ -1,0 +1,49 @@
+//
+//  GNWGS84Point.m
+//  GeoHashes
+//
+//  Created by AppTastic Technologies (www.apptastic.com.au) for GNS Science
+//  Copyright (c) 2012 GNS Science. All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import "GNWGS84Point.h"
+
+@implementation GNWGS84Point
+
+@synthesize latitude,longitude;
+
+-(id) initWithLatitude:(double)lat andLongitude:(double)lon
+{
+    //Initialization of a certain point
+    if (self = [super init])
+    {
+        self.latitude = lat;
+        self.longitude = lon;
+        
+        if ((fabs(self.latitude) > 90) || (fabs(self.longitude) > 180)) 
+        {
+            [NSException raise:@"Invalid coordinates" format:@"The supplied coordinates %f,%f are out of range.", self.latitude,self.longitude];
+        }
+    }
+    return self;
+}
+
+- (NSString*) description
+{
+    //Definition of string output for object
+    return [NSString stringWithFormat:@"%f,%f",self.latitude,self.longitude];
+}
+@end

--- a/GearRent/Models/Edge.h
+++ b/GearRent/Models/Edge.h
@@ -1,0 +1,20 @@
+//
+//  Edge.h
+//  GearRent
+//
+//  Created by Edwin Delgado on 7/20/22.
+//
+
+#import <Foundation/Foundation.h>
+#import "CoreLocation/CoreLocation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Edge : NSObject
+
+@property (assign, nonatomic) CLLocation *start;
+@property (assign, nonatomic) CLLocation *end;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GearRent/Models/Edge.m
+++ b/GearRent/Models/Edge.m
@@ -1,0 +1,12 @@
+//
+//  Edge.m
+//  GearRent
+//
+//  Created by Edwin Delgado on 7/20/22.
+//
+
+#import "Edge.h"
+
+@implementation Edge
+
+@end

--- a/GearRent/Models/Item.h
+++ b/GearRent/Models/Item.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSMutableArray *reservations;
 @property (nonatomic, strong) NSMutableArray *availabilities;
 @property (nonatomic) Boolean isAlwaysAvailable;
+@property (nonatomic, strong) NSString *geohash;
 
 @end
 

--- a/GearRent/Models/Item.m
+++ b/GearRent/Models/Item.m
@@ -23,11 +23,10 @@
 @dynamic reservations;
 @dynamic availabilities;
 @dynamic isAlwaysAvailable;
+@dynamic geohash;
 
 + (nonnull NSString *)parseClassName {
     return @"Listing";
 }
-
-
 
 @end

--- a/GearRent/Models/Reservation.h
+++ b/GearRent/Models/Reservation.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *leaseeId;
 @property (nonatomic, strong) TimeInterval *dates;
 @property (nonatomic, strong) NSString *status;
+@property (nonatomic, strong) NSString *geohash;
 
 @end
 

--- a/GearRent/Models/Reservation.m
+++ b/GearRent/Models/Reservation.m
@@ -15,6 +15,7 @@
 @dynamic leaseeId;
 @dynamic dates;
 @dynamic status;
+@dynamic geohash;
 
 + (nonnull NSString *)parseClassName {
     return @"Reservation";

--- a/GearRent/Networking/APIManager.h
+++ b/GearRent/Networking/APIManager.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface APIManager : NSObject
 
-void fetchListingsWithCoordinates(NSArray<CLLocation *> *coordinates, void(^)(NSArray<Item *> *, NSError *error));
+void fetchListingsWithCoordinates(NSArray<CLLocation *> *coordinates, void(^completion)(NSArray<Item *> *, NSError *error));
 
 @end
 

--- a/GearRent/Networking/APIManager.h
+++ b/GearRent/Networking/APIManager.h
@@ -1,0 +1,20 @@
+//
+//  APIManager.h
+//  GearRent
+//
+//  Created by Edwin Delgado on 7/20/22.
+//
+
+#import <Foundation/Foundation.h>
+#import "Item.h"
+#import "GNGeoHash.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface APIManager : NSObject
+
+void fetchListingsWithCoordinates(NSArray<CLLocation *> *coordinates, void(^)(NSArray<Item *> *, NSError *error));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GearRent/Networking/APIManager.m
+++ b/GearRent/Networking/APIManager.m
@@ -1,0 +1,165 @@
+//
+//  APIManager.m
+//  GearRent
+//
+//  Created by Edwin Delgado on 7/20/22.
+//
+
+#import "APIManager.h"
+#import "Parse/Parse.h"
+#import "GNGeoHash.h"
+#import "CoreLocation/CoreLocation.h"
+#import "Edge.h"
+#import "Item.h"
+
+static int const kMaxGeoHashPrecision = 7;
+
+@implementation APIManager
+
++ (void)fetchListingsWithPolygonCoordinates:(NSArray<CLLocation *> *)polygonCoordinates completion:(void(^)(NSArray<Item *> *listings, NSError *error))completion{
+    // Find all the geohashes within the polygon and return nil if no geohashes with precision 7 exist
+    NSMutableSet<GNGeoHash *> *geohashesWithinPolygon = [NSMutableSet<GNGeoHash *> new];
+    for(int i = 1; i <= kMaxGeoHashPrecision; i ++) {
+        geohashesWithinPolygon = [self findAllGeohashesWithinPolygon:polygonCoordinates precision:i];
+        if([geohashesWithinPolygon count] > 0) {
+            break;
+        }
+    }
+    if([geohashesWithinPolygon count] == 0) {
+        NSError *error = [NSError errorWithDomain:@"someDomain" code:404 userInfo:@{@"Error reason": @"Polygon too small"}];
+        completion(nil, error);
+        return;
+    }
+    NSArray *geohashesArray = [geohashesWithinPolygon allObjects];
+    NSMutableArray<NSString *> *geohashesStringArray = [NSMutableArray<NSString *> new];
+    for(int i = 0; i < geohashesArray.count; i++) {
+        [geohashesStringArray addObject:[geohashesArray[i] toBase32]];
+    }
+    [PFCloud callFunctionInBackground:@"getListingsWithGeohashes"
+                       withParameters:@{@"geohashes": geohashesStringArray}
+                                block:^(NSArray *listings, NSError *error) {
+      if (!error) {
+          NSLog(@"%@", listings); // complete with listings after
+      }
+    }];
+}
+
++ (NSMutableSet<GNGeoHash *> *)findAllGeohashesWithinPolygon:(NSArray<CLLocation *> *)polygonCoordinates precision:(int)precision {
+    // Finds all the geohashes within a polygon.
+    // Objective-c adaptation of https://gis.stackexchange.com/a/281017
+    NSMutableSet<GNGeoHash *> *uncheckedGeohashes = [NSMutableSet<GNGeoHash *> new];
+    NSMutableSet<GNGeoHash *> *insideGeohashes = [NSMutableSet<GNGeoHash *> new];
+    NSMutableSet<GNGeoHash *> *outsideGeohashes = [NSMutableSet<GNGeoHash *> new];
+    for(int i = 0; i < polygonCoordinates.count; i++) {
+        CLLocation *location = polygonCoordinates[i];
+        GNGeoHash *gh = [GNGeoHash withCharacterPrecision:location.coordinate.latitude andLongitude:location.coordinate.longitude andNumberOfCharacters:precision];
+        NSArray<GNGeoHash *> *adjacentGeohashes = [gh getAdjacent];
+        for(GNGeoHash * geohash in adjacentGeohashes) {
+            if([self polygonContainsGeohash:polygonCoordinates geohash:geohash]) {
+                [uncheckedGeohashes addObject:geohash];
+            }
+        }
+    }
+    while (uncheckedGeohashes.count > 0) {
+        GNGeoHash *currGH = [uncheckedGeohashes anyObject];
+        [uncheckedGeohashes removeObject:currGH];
+        if([self polygonContainsGeohash:polygonCoordinates geohash:currGH]) {
+            [insideGeohashes addObject:currGH];
+            NSArray *neighbors = [currGH getAdjacent];
+            for(GNGeoHash *neighbor in neighbors) {
+                if(![insideGeohashes containsObject:neighbor] && ![outsideGeohashes containsObject:neighbor] && ![uncheckedGeohashes containsObject:neighbor] && [self polygonContainsGeohash:polygonCoordinates geohash:neighbor]) {
+                    [uncheckedGeohashes addObject:neighbor];
+                }
+            }
+        } else {
+            [outsideGeohashes addObject:currGH];
+        }
+    }
+    return insideGeohashes;
+}
+
++ (BOOL)polygonContainsGeohash:(NSArray<CLLocation *> *)polygonCoordinates geohash:(GNGeoHash *)geohash {
+    NSMutableArray<CLLocation *> *currGHCorners = [self getFourCornersOfGeohash:geohash];
+    for(int i = 0; i < currGHCorners.count; i ++) {
+        CLLocation *currCorner = currGHCorners[i];
+        if(![self polygonContainsPoint:polygonCoordinates point:currCorner]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
++ (BOOL)polygonContainsPoint:(NSArray<CLLocation *> *)polygonCoordinates point:(CLLocation *)point {
+    // Determines if a polygon contains a given point using ray casting algorithim.
+    // Objective-C adaptation of http://philliplemons.com/posts/ray-casting-algorithm
+    // TODO: Modify function to work on lat/long boundaries
+    BOOL inside = NO;
+    NSMutableArray<Edge *> *edges = [self getPolygonEdges:polygonCoordinates];
+    for(int i = 0; i < edges.count; i ++) {
+        Edge *curr = edges[i];
+        CLLocation *lowestPoint = curr.start; // A
+        CLLocation *highestPoint = curr.end; // B
+        // Note: latitude = y and longitude = x
+        if(lowestPoint.coordinate.latitude > highestPoint.coordinate.latitude) {
+            lowestPoint = curr.end;
+            highestPoint = curr.start;
+        }
+        if([self isPointSameHeightAsEdge:curr point:point]) {
+            point = [[CLLocation alloc] initWithLatitude:point.coordinate.latitude + DBL_EPSILON longitude:point.coordinate.longitude];
+        }
+        if(point.coordinate.latitude <= highestPoint.coordinate.latitude && point.coordinate.latitude >= lowestPoint.coordinate.latitude && point.coordinate.longitude <= MAX(lowestPoint.coordinate.longitude, highestPoint.coordinate.longitude)) {
+            if(point.coordinate.longitude >= MIN(lowestPoint.coordinate.longitude, highestPoint.coordinate.longitude)) {
+                double slopeOfEdge = 0.0;
+                double slopeOfPoint = 0.0;
+                @try {
+                    slopeOfEdge = (highestPoint.coordinate.latitude - lowestPoint.coordinate.latitude) / (highestPoint.coordinate.longitude - lowestPoint.coordinate.longitude);
+                } @catch (NSException *exception) {
+                    slopeOfEdge = DBL_MAX;
+                }
+                @try {
+                    slopeOfPoint = (point.coordinate.latitude - lowestPoint.coordinate.latitude) / (point.coordinate.longitude - lowestPoint.coordinate.longitude);
+                } @catch (NSException *exception) {
+                    slopeOfPoint = DBL_MAX;
+                }
+                if(slopeOfPoint >= slopeOfEdge) { // ray intersects with edge
+                    inside = !inside;
+                }
+            }else { // ray intersects with edge
+                inside = !inside;
+            }
+        }
+    }
+    return inside;
+}
+
++ (BOOL)isPointSameHeightAsEdge:(Edge *)edge point:(CLLocation *)point {
+    if(fabs(point.coordinate.latitude - edge.start.coordinate.latitude) < DBL_EPSILON ||
+       fabs(point.coordinate.latitude - edge.end.coordinate.latitude) < DBL_EPSILON) {
+        return YES;
+    }
+    return NO;
+}
+
++ (NSMutableArray<Edge *> *)getPolygonEdges:(NSArray<CLLocation *> *)polygonCoordinates {
+    NSMutableArray<Edge *> *result = [NSMutableArray<Edge *> new];
+    for(int i = 0; i < polygonCoordinates.count; i ++) {
+        Edge *edge = [[Edge alloc] init];
+        edge.start = (CLLocation *)polygonCoordinates[i];
+        edge.end = (CLLocation *)polygonCoordinates[(i + 1) % polygonCoordinates.count];
+        [result addObject:edge];
+    }
+    return result;
+}
+
++ (NSMutableArray<CLLocation *> *)getFourCornersOfGeohash:(GNGeoHash *)geohash {
+    NSMutableArray<CLLocation *> *result = [NSMutableArray<CLLocation *> new];
+    GNWGS84Point *upperLeftPoint =  [geohash.boundingBox getUpperLeft];
+    GNWGS84Point *lowerRightPoint = [geohash.boundingBox getLowerRight];
+    [result addObject:[[CLLocation alloc] initWithLatitude:upperLeftPoint.latitude longitude:upperLeftPoint.longitude]];
+    [result addObject:[[CLLocation alloc] initWithLatitude:lowerRightPoint.latitude longitude:lowerRightPoint.longitude]];
+    [result addObject:[[CLLocation alloc] initWithLatitude:lowerRightPoint.latitude longitude:upperLeftPoint.longitude]];
+    [result addObject:[[CLLocation alloc] initWithLatitude:upperLeftPoint.latitude longitude:lowerRightPoint.longitude]];
+    return result;
+}
+
+@end

--- a/GearRent/ViewControllers/CreateListingViewController.m
+++ b/GearRent/ViewControllers/CreateListingViewController.m
@@ -15,6 +15,7 @@
 #import "Reservation.h"
 #import "MapKit/MapKit.h"
 #import "CoreLocation/CoreLocation.h"
+#import "GNGeoHash.h"
 
 @interface CreateListingViewController ()<UICollectionViewDataSource, UICollectionViewDelegate, JTCalendarDelegate,ProfileImagePickerViewControllerDelegate, MKMapViewDelegate, CLLocationManagerDelegate>
 @property (strong, nonatomic) IBOutlet UIView *calendarView;
@@ -168,6 +169,9 @@
     newItem.city = self.cityTextField.text;
     newItem.availabilities =  [self getTimeIntervals:self.datesSelected];
     newItem.isAlwaysAvailable = [self.isAlwaysAvailableSwitch isOn];
+    // TODO: add utils class with constants such as geohash precision
+    GNGeoHash *geohash = [GNGeoHash withCharacterPrecision:newItem.geoPoint.latitude  andLongitude:newItem.geoPoint.longitude andNumberOfCharacters:7];
+    newItem.geohash = [geohash toBase32];
     [newItem saveInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
         if(succeeded){
             NSLog(@"END: Item successfully saved");

--- a/GearRent/ViewControllers/GearForRentViewController.m
+++ b/GearRent/ViewControllers/GearForRentViewController.m
@@ -14,6 +14,7 @@
 #import "MapKit/MapKit.h"
 #import "CoreLocation/CoreLocation.h"
 #import "APIManager.h"
+#import "Item.h"
 
 @interface GearForRentViewController ()<UITableViewDelegate, UITableViewDataSource, MKMapViewDelegate, CLLocationManagerDelegate>
 
@@ -43,6 +44,7 @@
     self.listingsTableView.dataSource = self;
     self.mapView.hidden = YES;
     self.removePointsButton.hidden = YES;
+    self.searchPolygonButton.hidden = YES;
     self.listingTypeButton.titleLabel.text = @"Map";
     self.mapView.delegate = self;
     self.locationManager = [CLLocationManager new];
@@ -151,15 +153,23 @@
     [navigationVC pushViewController:detailsVC animated:YES];
 }
 
-//- (IBAction)didSearchPolygon:(id)sender {
-//    [APIManager fetchListingsWithCoordinates:self.mapPoints completion:^(NSArray<Item *> * _Nonnull listings, NSError * _Nonnull error) {
-//        if(error == nil){
-//            NSLog(@"END: Success in fetching listings from polygon");
-//        } else{
-//            NSLog(@"END: Failed to fetch listings from polygon");
-//        }
-//    }];
-//}
+- (IBAction)didSearchPolygon:(id)sender {
+    void(^completion)(NSArray<Item *> *, NSError *error) = ^void(NSArray<Item *> *listings, NSError *error){
+        if(error == nil){
+            NSLog(@"END: Successfully searched for listings in polygon");
+            for(int i = 0; i < listings.count; i ++){
+                Item *listing = listings[i];
+                MKPointAnnotation *pa = [[MKPointAnnotation alloc] init];
+                pa.coordinate = CLLocationCoordinate2DMake(listing.geoPoint.latitude, listing.geoPoint.longitude);
+                pa.title = listing.title;
+                [self.mapView addAnnotation:pa];
+            }
+        } else{
+            NSLog(@"END: Error in didSearchPolygon");
+        }
+    };
+    fetchListingsWithCoordinates(self.mapPoints, completion);
+}
 
 - (IBAction)didRemovePoints:(id)sender {
     [self.mapPoints removeAllObjects];
@@ -172,10 +182,12 @@
     if([self.mapView isHidden]){
         [self.mapView setHidden:NO];
         [self.removePointsButton setHidden:NO];
+        [self.searchPolygonButton setHidden:NO];
         [self.listingTypeButton.titleLabel setText:@"List"];
     } else{
         [self.mapView setHidden:YES];
-        [self.mapView setHidden:YES];
+        [self.removePointsButton setHidden:YES];
+        [self.searchPolygonButton setHidden:YES];
         [self.listingTypeButton.titleLabel setText:@"Map"];
     }
 }

--- a/GearRent/ViewControllers/GearForRentViewController.m
+++ b/GearRent/ViewControllers/GearForRentViewController.m
@@ -11,13 +11,25 @@
 #import "Parse/Parse.h"
 #import "ListingTableViewCell.h"
 #import "DetailsViewController.h"
+#import "MapKit/MapKit.h"
+#import "CoreLocation/CoreLocation.h"
+#import "APIManager.h"
 
-@interface GearForRentViewController ()<UITableViewDelegate, UITableViewDataSource>
+@interface GearForRentViewController ()<UITableViewDelegate, UITableViewDataSource, MKMapViewDelegate, CLLocationManagerDelegate>
 
 @property (strong, nonatomic) NSArray *tableData;
 @property (strong, nonatomic) IBOutlet UITableView *listingsTableView;
+@property (strong, nonatomic) IBOutlet MKMapView *mapView;
+@property (strong, nonatomic) CLLocationManager *locationManager;
+@property (strong, nonatomic) IBOutlet UIButton *listingTypeButton;
+@property (strong, nonatomic) NSMutableArray<CLLocation *> *mapPoints;
+@property (strong, nonatomic) IBOutlet UIButton *removePointsButton;
+@property (strong, nonatomic) IBOutlet UIButton *searchPolygonButton;
 
 - (IBAction)didLogOut:(id)sender;
+- (IBAction)didChangeListing:(id)sender;
+- (IBAction)didRemovePoints:(id)sender;
+- (IBAction)didSearchPolygon:(id)sender;
 
 @end
 
@@ -26,12 +38,91 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
+    self.mapPoints = [NSMutableArray<CLLocation *> new];
     self.listingsTableView.delegate = self;
     self.listingsTableView.dataSource = self;
+    self.mapView.hidden = YES;
+    self.removePointsButton.hidden = YES;
+    self.listingTypeButton.titleLabel.text = @"Map";
+    self.mapView.delegate = self;
+    self.locationManager = [CLLocationManager new];
+    self.locationManager.delegate = self;
+    self.locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters;
+    self.locationManager.distanceFilter = 200;
+    [self.locationManager requestWhenInUseAuthorization];
+    UITapGestureRecognizer *fingerTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapFingerTap:)];
+    fingerTap.numberOfTapsRequired = 1;
+    fingerTap.numberOfTouchesRequired = 1;
+    [self.mapView addGestureRecognizer:fingerTap];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [self fetchData];
+}
+
+- (MKOverlayRenderer *)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay
+{
+    if ([overlay isKindOfClass:[MKPolygon class]])
+    {
+        MKPolygonRenderer *renderer = [[MKPolygonRenderer alloc] initWithPolygon:overlay];
+        renderer.strokeColor = [[UIColor whiteColor] colorWithAlphaComponent:0.7];
+        renderer.lineWidth   = 2;
+        return renderer;
+    }
+    return nil;
+}
+
+- (void)handleMapFingerTap:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer.state != UIGestureRecognizerStateEnded) {
+        return;
+    }
+    CGPoint touchPoint = [gestureRecognizer locationInView:self.mapView];
+    CLLocationCoordinate2D touchMapCoordinate =
+    [self.mapView convertPoint:touchPoint toCoordinateFromView:self.mapView];
+    MKPointAnnotation *pa = [[MKPointAnnotation alloc] init];
+    pa.coordinate = touchMapCoordinate;
+    pa.title = @"Polygon vertice";
+    [self.mapView addAnnotation:pa];
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:touchMapCoordinate.latitude longitude:touchMapCoordinate.longitude];
+    [self.mapPoints addObject: location];
+    [self renderMapPoints];
+}
+
+- (void)renderMapPoints{
+    // TODO: create a function to validate that no polygon segments overlap
+    NSUInteger count = self.mapPoints.count;
+    if(self.mapView.overlays.count > 0){
+        [self.mapView removeOverlays:self.mapView.overlays];
+    }
+    if(count > 2){
+        CLLocationCoordinate2D coordinates[count];
+        for(int i = 0; i < count; i++){
+            coordinates[i] = self.mapPoints[i].coordinate;
+        }
+        MKPolygon *polygon = [MKPolygon polygonWithCoordinates: coordinates count: count];
+        [self.mapView addOverlay:polygon];
+    }
+}
+
+- (double)getDistance:(CLLocation *)pointA pointB:(CLLocation *)pointB{
+    return sqrt(pow(pointA.coordinate.latitude - pointB.coordinate.latitude, 2.0) +
+                pow(pointA.coordinate.longitude - pointB.coordinate.longitude, 2.0));
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    if(status == kCLAuthorizationStatusAuthorizedWhenInUse){
+        [self.locationManager startUpdatingLocation];
+    }
+}
+
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    [self.locationManager startUpdatingLocation];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    MKCoordinateSpan span = MKCoordinateSpanMake(0.1, 0.1);
+    MKCoordinateRegion region = MKCoordinateRegionMake(locations[0].coordinate, span);
+    [self.mapView setRegion:region];
 }
 
 -(void)fetchData {
@@ -58,6 +149,35 @@
     DetailsViewController *detailsVC = (DetailsViewController *) [storyboard instantiateViewControllerWithIdentifier:@"DetailsViewController"];
     detailsVC.listing = (Item *) self.tableData[indexPath.row];
     [navigationVC pushViewController:detailsVC animated:YES];
+}
+
+//- (IBAction)didSearchPolygon:(id)sender {
+//    [APIManager fetchListingsWithCoordinates:self.mapPoints completion:^(NSArray<Item *> * _Nonnull listings, NSError * _Nonnull error) {
+//        if(error == nil){
+//            NSLog(@"END: Success in fetching listings from polygon");
+//        } else{
+//            NSLog(@"END: Failed to fetch listings from polygon");
+//        }
+//    }];
+//}
+
+- (IBAction)didRemovePoints:(id)sender {
+    [self.mapPoints removeAllObjects];
+    NSArray *annotations = self.mapView.annotations;
+    [self.mapView removeAnnotations:annotations];
+    [self.mapView removeOverlays:self.mapView.overlays];
+}
+
+- (IBAction)didChangeListing:(id)sender {
+    if([self.mapView isHidden]){
+        [self.mapView setHidden:NO];
+        [self.removePointsButton setHidden:NO];
+        [self.listingTypeButton.titleLabel setText:@"List"];
+    } else{
+        [self.mapView setHidden:YES];
+        [self.mapView setHidden:YES];
+        [self.listingTypeButton.titleLabel setText:@"Map"];
+    }
 }
 
 - (IBAction)didLogOut:(id)sender {

--- a/GearRent/ViewControllers/MyListingsViewController.m
+++ b/GearRent/ViewControllers/MyListingsViewController.m
@@ -32,6 +32,7 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self fetchData];
 }
 

--- a/GearRentTests/GearRentTests.m
+++ b/GearRentTests/GearRentTests.m
@@ -6,6 +6,8 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "APIManager.h"
+#import "float.h"
 
 @interface GearRentTests : XCTestCase
 
@@ -21,9 +23,29 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testPolygonContainsPoint{
+//    NSMutableArray<CLLocation *> *coordinates = [NSMutableArray<CLLocation *> new];
+//    [coordinates addObject:[[CLLocation alloc] initWithLatitude:49.342796 longitude:-127.278627]];
+//    [coordinates addObject:[[CLLocation alloc] initWithLatitude:49.342796 longitude:-101.685734]];
+//    [coordinates addObject:[[CLLocation alloc] initWithLatitude:37.670506 longitude:-101.685734]];
+//    [coordinates addObject:[[CLLocation alloc] initWithLatitude:37.670506 longitude:-127.278627]];
+    
+    NSMutableArray<CLLocation *> *coordinates = [NSMutableArray<CLLocation *> new];
+    double topLeftLat = 47.629015;
+    double topLeftLong = -122.331929;
+    double botRightLat = 47.612416;
+    double botRightLong = -122.301203;
+    [coordinates addObject:[[CLLocation alloc] initWithLatitude:topLeftLat longitude:topLeftLong]];
+    [coordinates addObject:[[CLLocation alloc] initWithLatitude:topLeftLat longitude:botRightLong]];
+    [coordinates addObject:[[CLLocation alloc] initWithLatitude:botRightLat longitude:botRightLong]];
+    [coordinates addObject:[[CLLocation alloc] initWithLatitude:botRightLat longitude:topLeftLong]];
+    
+    CLLocation *point = [[CLLocation alloc] initWithLatitude:botRightLat + 0.1 longitude:botRightLong - 0.1];
+    
+    NSMutableSet<GNGeoHash *> *geohashes = [APIManager findAllGeohashesWithinPolygon:coordinates precision:6];
+    for(GNGeoHash * geohash in [geohashes allObjects]){
+        NSLog(@"%@", [geohash toBase32]);
+    }
 }
 
 - (void)testPerformanceExample {


### PR DESCRIPTION
## Description
- Implements algorithm to find the largest possible geohashes within a polygon down to a certain predetermined character precision (in this case 7 characters)
- - once largest geohash is found, only queries the geohashes with all four corners in the polygon.
- - used [this ](http://philliplemons.com/posts/ray-casting-algorithm)algorithm to determine if point was within polygon edges.
- - used [this](https://gis.stackexchange.com/questions/219834/library-to-convert-polygon-to-geohash/281017#281017) algorithm to find all the geohashes within a polygon given a certain geohash precision length.
-  Later PRs will focus on handling error and edge cases as well as polishing the UI(multiple polygons, lat/long boundaries, polygons with large number of vertices)


## Milestones
- Adds ability to find all the geohashes within a given polygon the users draws on the map and queries the database with those geohashes 
- Once given those geohashes, the database can efficiently find listings within the area as described here: https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Query.html#startsWith
- Displays the listings found on the map

## Test Plan
- demo with parse cloud code log and confirmation of cloud code execution


 <video src="https://user-images.githubusercontent.com/71790814/180870032-6363524d-abca-4dca-9244-cbb168a4b2fd.mov" controls="controls" style="max-width: 730px;">
</video>
- Parse cloud code: 
<img width="540" alt="Screen Shot 2022-07-25 at 1 40 52 PM" src="https://user-images.githubusercontent.com/71790814/180870324-0e249153-8c81-45b7-90b1-f2254a08be43.png">



