### PR TITLE
added ability to add excluding polygons

### DIFF
--- a/GearRent/Base.lproj/Main.storyboard
+++ b/GearRent/Base.lproj/Main.storyboard
@@ -375,15 +375,25 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QeK-2H-XFO">
+                                <rect key="frame" x="121.5" y="683" width="171" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Add excluding polygon"/>
+                                <connections>
+                                    <action selector="didAddExcludingPolygon:" destination="lfo-Q5-Z1C" eventType="touchUpInside" id="2KP-9q-8nA"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ECP-49-BTE"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Q2s-2x-eAY" firstAttribute="top" secondItem="i0z-mB-Msk" secondAttribute="bottom" constant="-61" id="0IW-oA-u6s"/>
+                            <constraint firstItem="Q2s-2x-eAY" firstAttribute="top" secondItem="QeK-2H-XFO" secondAttribute="bottom" constant="38" id="1mN-FW-WDd"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="ECP-49-BTE" secondAttribute="leading" id="7Gc-9G-NZu"/>
                             <constraint firstItem="EyR-LR-Eqx" firstAttribute="trailing" secondItem="i0z-mB-Msk" secondAttribute="trailing" constant="-30" id="9em-hp-4I4"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="leading" secondItem="Q2s-2x-eAY" secondAttribute="leading" constant="-30" id="DwV-Il-3GY"/>
                             <constraint firstItem="i0z-mB-Msk" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="39" id="F1c-9X-J3m"/>
+                            <constraint firstItem="QeK-2H-XFO" firstAttribute="centerX" secondItem="ECP-49-BTE" secondAttribute="centerX" id="FHk-9P-F4i"/>
                             <constraint firstItem="ECP-49-BTE" firstAttribute="trailing" secondItem="hO8-AN-EIT" secondAttribute="trailing" id="FhV-m4-zOe"/>
                             <constraint firstItem="my2-Dr-Gg9" firstAttribute="top" secondItem="ECP-49-BTE" secondAttribute="top" constant="60" id="K6d-PW-813"/>
                             <constraint firstItem="l2F-vq-xui" firstAttribute="centerX" secondItem="i0z-mB-Msk" secondAttribute="centerX" id="KHF-eX-Bqo"/>
@@ -427,6 +437,7 @@
                     <connections>
                         <outlet property="FiltersButton" destination="l2F-vq-xui" id="xOu-Vu-TEb"/>
                         <outlet property="FiltersTableView" destination="hO8-AN-EIT" id="ryZ-EH-qDv"/>
+                        <outlet property="addExcludingPolygonButton" destination="QeK-2H-XFO" id="6Vp-ag-k46"/>
                         <outlet property="listingTypeButton" destination="Dui-rG-vLK" id="KaA-hv-bSN"/>
                         <outlet property="listingsTableView" destination="duf-Qh-adg" id="wQj-SV-Aih"/>
                         <outlet property="mapView" destination="i0z-mB-Msk" id="fzd-iw-Crn"/>

--- a/GearRent/Networking/APIManager.h
+++ b/GearRent/Networking/APIManager.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern void fetchAllCategories(void(^completion)(NSArray<Category *> *, NSError *));
 extern void fetchDynamicPrice(Listing *listing, NSMutableArray<NSMutableArray<NSNumber *> *> *dateRanges, void(^completion)(NSDictionary<NSNumber *, NSNumber *> *, NSError *));
-extern void fetchListingsWithCoordinates(NSArray<CLLocation *> *coordinates, void(^completion)(NSArray<Listing *> *, NSError *error));
+extern void fetchListingsWithPolygons(NSArray<CLLocation *> *outerPolygonCoordinates,NSArray<NSArray<CLLocation *>*> *innerPolygonCoordinates, void(^completion)(NSArray<Listing *> *, NSError *error));
 
 @interface APIManager : NSObject
 

--- a/GearRent/Networking/APIManager.h
+++ b/GearRent/Networking/APIManager.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern void fetchAllCategories(void(^completion)(NSArray<Category *> *, NSError *));
 extern void fetchDynamicPrice(Listing *listing, NSMutableArray<NSMutableArray<NSNumber *> *> *dateRanges, void(^completion)(NSDictionary<NSNumber *, NSNumber *> *, NSError *));
-extern void fetchListingsWithPolygons(NSArray<CLLocation *> *outerPolygonCoordinates,NSArray<NSArray<CLLocation *>*> *innerPolygonCoordinates, void(^completion)(NSArray<Listing *> *, NSError *error));
+extern void fetchListingsWithPolygons(NSArray<CLLocation *> * outerPolygonCoordinates, NSArray<NSArray<CLLocation *>*> * innerPolygonCoordinates, void(^completion)(NSArray<Listing *> *, NSError *error));
 
 @interface APIManager : NSObject
 


### PR DESCRIPTION
## Description
- Expanding on the previous algorithm which finds the geohashes in a polygon, this revised algorithm finds geohashes inside a larger polygon but excludes any inner polygons
- - can support unlimited number of excluding inner polygons
-  Later PRs will focus on handling error and edge cases as well as polishing the UI(lat/long boundaries, polygons with large number of vertices)


## Milestones
- Adds ability to find all the geohashes within a given polygon excluding any inner polygons the users draws on the map
- Once given those geohashes, the database can efficiently find listings within the area as described here: https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Query.html#startsWith
- Displays the listings found on the map

## Test Plan
- demo 

https://user-images.githubusercontent.com/71790814/183216692-05a99904-bff6-46db-91fc-a870b8a90ac8.mov




- Parse cloud code: 
<img width="540" alt="Screen Shot 2022-07-25 at 1 40 52 PM" src="https://user-images.githubusercontent.com/71790814/180870324-0e249153-8c81-45b7-90b1-f2254a08be43.png">




